### PR TITLE
refactor: rename CMake option LT_ADD_EXAMPLES to LT_BUILD_EXAMPLES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 ###########################################################################
 
 set(LT_UTILS ON)
-#set(LT_ADD_EXAMPLES ON)
+#set(LT_BUILD_EXAMPLES ON)
 
 # Use trezor crypto as a source of backend cryptography code
 set(LT_USE_TREZOR_CRYPTO ON)


### PR DESCRIPTION
There was [refactoring in libtropic repo](https://github.com/tropicsquare/libtropic/pull/103), so this makes it consistent with it.

@pavelpolach321 