### PR TITLE
feat(macos): add macOS compatibility support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ endif()
 #                                                                         #
 ###########################################################################
 
-target_link_options(lt-util PRIVATE -Wl,--gc-sections)
+if(APPLE)
+    target_link_options(lt-util PRIVATE -Wl,-dead_strip)
+    target_compile_options(lt-util PRIVATE -Wno-parentheses-equality -Wno-pointer-sign)
+elseif(UNIX)
+    target_link_options(lt-util PRIVATE -Wl,--gc-sections)
+    target_compile_options(lt-util PRIVATE -ffunction-sections -fdata-sections)
+endif()
 
 if(USB_DONGLE_TS1301)
     target_link_libraries(lt-util PRIVATE tropic)

--- a/test/run_tests_usb.sh
+++ b/test/run_tests_usb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 PATH_TO_BUILD="../build"
-UART_PORT="/dev/ttyACM0"
+UART_PORT="/dev/cu.usbmodem1b36004b37721"
 cd ${PATH_TO_BUILD}
 
 echo ""
@@ -11,7 +11,7 @@ echo "[COMMAND] RNG test expected fails with invalid length:"
 ./lt-util ${UART_PORT}  -r 256 message; echo "  Status: " $?
 echo "[COMMAND] Get 32 random bytes and save as message:"
 ./lt-util ${UART_PORT}  -r 32 message; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/message | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/message | tr -d '\n' && echo ""
 
 echo "[COMMAND] Erase slot 0: "
 ./lt-util ${UART_PORT}  -e -c 0; echo "  Status: " $?
@@ -19,20 +19,20 @@ echo "[COMMAND] Generate EdDSA keypair there: "
 ./lt-util ${UART_PORT}  -e -g 0; echo "  Status: " $?
 echo "[COMMAND] Get public key"
 ./lt-util ${UART_PORT}  -e -d 0 public_key; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/public_key | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/public_key | tr -d '\n' && echo ""
 
 echo "[COMMAND] Sign message 5 times"
 # Now sign the message five times
 ./lt-util ${UART_PORT}  -e -s 0 message signature1; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/signature1 | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/signature1 | tr -d '\n' && echo ""
 ./lt-util ${UART_PORT}  -e -s 0 message signature2; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/signature2 | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/signature2 | tr -d '\n' && echo ""
 ./lt-util ${UART_PORT}  -e -s 0 message signature3; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/signature3 | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/signature3 | tr -d '\n' && echo ""
 ./lt-util ${UART_PORT}  -e -s 0 message signature4; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/signature4 | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/signature4 | tr -d '\n' && echo ""
 ./lt-util ${UART_PORT}  -e -s 0 message signature5; echo "  Status: " $?
-#xxd -p ${PATH_TO_BUILD}/signature5 | tr -d '\n' && echo ""
+xxd -p ${PATH_TO_BUILD}/signature5 | tr -d '\n' && echo ""
 
 echo ""
 echo "[INFO] Verify five signatures with python cryptography library"


### PR DESCRIPTION
- Add platform-specific build configuration in CMakeLists.txt
- Use -Wl,-dead_strip for Apple systems instead of --gc-sections
- Add macOS-specific compiler warning suppressions
- Update USB test script for macOS device path format
- Enable hex output debugging in test script for better visibility
- Maintain backward compatibility with existing Unix/Linux builds