### PR TITLE
feat(macos): MacOS compatibility - fixed CMakeLists.txt and port enumeration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,13 @@ target_compile_definitions(lt-util PRIVATE "$<$<CONFIG:DEBUG>:LT_UTIL_DEBUG>")
 #   Link executable                                                       #
 #                                                                         #
 ###########################################################################
-
-target_link_options(lt-util PRIVATE -Wl,--gc-sections)
+if(APPLE)
+    target_link_options(lt-util PRIVATE -Wl,-dead_strip)
+    target_compile_options(lt-util PRIVATE -Wno-parentheses-equality -Wno-pointer-sign)
+elseif(UNIX)
+    target_link_options(lt-util PRIVATE -Wl,--gc-sections)
+    target_compile_options(lt-util PRIVATE -ffunction-sections -fdata-sections)
+endif()
 
 if(USB_DONGLE_TS1301 OR USB_DONGLE_TS1302)
     target_link_libraries(lt-util PRIVATE tropic)

--- a/test/run_tests_usb.sh
+++ b/test/run_tests_usb.sh
@@ -11,7 +11,7 @@
 # 6. Prints the status of each command executed.
 
 PATH_TO_BUILD="../build"
-UART_PORT="/dev/ttyACM0"
+UART_PORT=${1:-/dev/ttyACM0}
 cd ${PATH_TO_BUILD}
 
 


### PR DESCRIPTION
- Add platform-specific build configuration in CMakeLists.txt
- Use -Wl,-dead_strip for Apple systems instead of --gc-sections
- Add macOS-specific compiler warning suppressions
- Update USB test script for macOS device path format